### PR TITLE
Set dark mode as default and update color scheme to match etchwp.com branding

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -78,6 +78,9 @@ const config: Config = {
 	themeConfig: {
 		// Replace with your project's social card
 		image: 'img/docs-cover-image',
+		colorMode: {
+			defaultMode: 'dark',
+		},
 		navbar: {
 			title: 'Etch',
 			logo: {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -6,27 +6,34 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: oklch(0.6 0.065383 239.6884);
-  --ifm-color-primary-dark: hsl(205, 30%, 30%);
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary: #067a6c;
+  --ifm-color-primary-dark: #02312b;
+  --ifm-color-primary-darker: #02312b;
+  --ifm-color-primary-darkest: #02312b;
+  --ifm-color-primary-light: #08aa98;
+  --ifm-color-primary-lighter: #55f7e4;
+  --ifm-color-primary-lightest: #c6ece7;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: oklch(0.8046 0.065383 239.6884);
-  --ifm-color-primary-dark: #21af90;
+  --ifm-color-primary: #72f8e8;
+  --ifm-color-primary-dark: #55f7e4;
   --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary-darkest: #08aa98;
+  --ifm-color-primary-light: #55f7e4;
+  --ifm-color-primary-lighter: #c6ece7;
+  --ifm-color-primary-lightest: #c6ece7;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  --ifm-background-color: #1d1d20;
+  --ifm-background-surface-color: #27272b;
+}
+
+.footer--dark {
+  --ifm-footer-background-color: var(--ifm-background-surface-color);
 }
 
 .navbar__logo {


### PR DESCRIPTION
## Description

- Set dark mode as default to match Etch branding
- Updated colors to match Etch's new colors

## Type of change

Please check the box that best describes your changes.

- [x] Other improvement (please describe)

## How have you verified your changes?

Please describe how you've checked that your changes look correct.

- [x] I have run `npm run dev` and viewed my changes locally.
- [x] The changes look correct on the preview.

## Checklist

- [x] I have read the **CONTRIBUTING.md**.
- [x] I have performed a self-review of my own changes.
- [x] My changes are easy to understand.
